### PR TITLE
Add IPv6 DHT support

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ function Discovery (opts) {
   self._internalDHT = false // is the DHT created internally?
   self._internalDHT6 = false
   self.dhtPort = null
-  self.dht = null;
-  self.dht6 = null;
+  self.dht = null
+  self.dht6 = null
 
   self._onWarning = function (err) {
     self.emit('warning', err)
@@ -76,9 +76,7 @@ function Discovery (opts) {
   initDHT('dht')
   initDHT('dht6')
 
-
-  function initDHT(field) {
-
+  function initDHT (field) {
     if (opts[field] === false || typeof DHT !== 'function') {
       self[field] = null
     } else if (opts[field] && typeof opts[field].addNode === 'function') {
@@ -86,7 +84,7 @@ function Discovery (opts) {
     } else if (opts[field] && typeof opts[field] === 'object') {
       self[field] = createDHT(opts.dhtPort, field, opts[field])
     } else {
-      self[field] = createDHT(opts.dhtPort, field);
+      self[field] = createDHT(opts.dhtPort, field)
     }
 
     if (self[field]) {
@@ -101,7 +99,7 @@ function Discovery (opts) {
     var dht = new DHT(opts)
     dht.on('warning', self._onWarning)
     dht.on('error', self._onError)
-    dht.listen(port);
+    dht.listen(port)
 
     self[field === 'dht6' ? '_internalDHT6' : '_internalDHT'] = true
     return dht
@@ -113,7 +111,7 @@ Discovery.prototype.updatePort = function (port, ipv6) {
   if (port === self._port) return
   self._port = port
 
-  if (self.dht)  { self._dhtAnnounce(self.dht)  }
+  if (self.dht) { self._dhtAnnounce(self.dht) }
   if (self.dht6) { self._dhtAnnounce(self.dht6) }
 
   if (self.tracker) {
@@ -173,7 +171,7 @@ Discovery.prototype.destroy = function (cb) {
   self._announce = null
 }
 
-Discovery.prototype._cleanupDHT = function(dht, tasks) {
+Discovery.prototype._cleanupDHT = function (dht, tasks) {
   dht.removeListener('warning', this._onWarning)
   dht.removeListener('error', this._onError)
   tasks.push(function (cb) {
@@ -201,7 +199,7 @@ Discovery.prototype._createTracker = function () {
 
 Discovery.prototype._dhtAnnounce = function (dht) {
   var self = this
-  var field = '_dhtAnnouncing' + (dht.ipv6 ? '6' : '');
+  var field = '_dhtAnnouncing' + (dht.ipv6 ? '6' : '')
   if (self[field]) return
   debug('dht (IPv6: ' + dht.ipv6 + ') announce')
 

--- a/index.js
+++ b/index.js
@@ -55,9 +55,12 @@ function Discovery (opts) {
     if (net.isIPv6(peer.host)) {
       host = '[' + peer.host + ']'
     }
-    self.emit('peer', host + ':' + peer.port)
+    var addr = host + ':' + peer.port
+    debug('DHT peer: ' + addr)
+    self.emit('peer', addr)
   }
   self._onTrackerPeer = function (peer) {
+    debug('Tracker peer: ' + peer)
     self.emit('peer', peer)
   }
   self._onTrackerAnnounce = function () {

--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ Discovery.prototype._createTracker = function () {
 
 Discovery.prototype._dhtAnnounce = function (dht) {
   var self = this
-  var field = '_dhtAnnouncing' + dht.ipv6 ? '6' : '';
+  var field = '_dhtAnnouncing' + (dht.ipv6 ? '6' : '');
   if (self[field]) return
   debug('dht (IPv6: ' + dht.ipv6 + ') announce')
 

--- a/test/announce.js
+++ b/test/announce.js
@@ -2,24 +2,26 @@ var DHT = require('bittorrent-dht')
 var Discovery = require('../')
 var randombytes = require('randombytes')
 var test = require('tape')
+var common = require('./common')
 
-test('initialize with dht', function (t) {
+common.wrapTest(test, 'initialize with dht', function (t, ipv6) {
   t.plan(5)
-  var dht = new DHT({ bootstrap: false })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   var discovery = new Discovery({
     infoHash: randombytes(20),
     peerId: randombytes(20),
     port: 6000,
-    dht: dht,
+    dht: ipv6 ? false : dht,
+    dht6: ipv6 ? dht : false,
     intervalMs: 1000
   })
 
   var _dhtAnnounce = discovery._dhtAnnounce
   var num = 0
-  discovery._dhtAnnounce = function () {
+  discovery._dhtAnnounce = function (dht) {
     num += 1
     t.pass('called once after 1000ms')
-    _dhtAnnounce.call(discovery)
+    _dhtAnnounce.call(discovery, dht)
     if (num === 4) {
       discovery.destroy(function () {
         dht.destroy(function () {

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,11 +3,6 @@ var DHT = require('bittorrent-dht')
 var randombytes = require('randombytes')
 var test = require('tape')
 var common = require('./common')
-/* var log = require('why-is-node-running')
-
-setInterval(function () {
-  log() // logs out active handles that are keeping node running
-}, 5000) */
 
 common.wrapTest(test, 'initialize with dht', function (t, ipv6) {
   t.plan(1)

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,15 +2,22 @@ var Discovery = require('../')
 var DHT = require('bittorrent-dht')
 var randombytes = require('randombytes')
 var test = require('tape')
+var common = require('./common')
+/*var log = require('why-is-node-running')
 
-test('initialize with dht', function (t) {
+setInterval(function () {
+  log() // logs out active handles that are keeping node running
+}, 5000)*/
+
+common.wrapTest(test, 'initialize with dht', function (t, ipv6) {
   t.plan(1)
-  var dht = new DHT()
+  var dht = new DHT({ipv6: ipv6})
   var discovery = new Discovery({
     infoHash: randombytes(20),
     peerId: randombytes(20),
     port: 6000,
-    dht: dht
+    dht: ipv6 ? false : dht,
+    dht6: ipv6 ? dht : false
   })
   discovery.destroy(function () {
     dht.destroy(function () {
@@ -19,28 +26,65 @@ test('initialize with dht', function (t) {
   })
 })
 
-test('initialize with default dht', function (t) {
+common.wrapTest(test, 'initialize with default dht', function (t, ipv6) {
   t.plan(1)
   var discovery = new Discovery({
     infoHash: randombytes(20),
     peerId: randombytes(20),
-    port: 6000
+    port: 6000,
+    dht: !ipv6,
+    dht6: ipv6
   })
   discovery.destroy(function () {
     t.pass()
   })
 })
 
-test('initialize without dht', function (t) {
+common.wrapTest(test, 'initialize without dht', function (t, ipv6) {
   t.plan(2)
   var discovery = new Discovery({
     infoHash: randombytes(20),
     peerId: randombytes(20),
     port: 6000,
-    dht: false
+    dht: false,
+    dht6: false
   })
   t.equal(discovery.dht, null)
   discovery.destroy(function () {
     t.pass()
   })
 })
+
+test('use ipv4 and ipv6 together', function(t) {
+  t.plan(3)
+
+  var dhtv4 = new DHT({ipv6: false})
+  var dhtv6 = new DHT({ipv6: true})
+
+  var infoHash = randombytes(20)
+
+  var discovery = new Discovery({
+    infoHash: infoHash,
+    peerId: randombytes(20),
+    port: 6000,
+    dht: dhtv4,
+    dht6: dhtv6
+  })
+
+  discovery.once('peer', function (addr) {
+    t.equal(addr, '[::1]:8000')
+  })
+  dhtv4.emit('peer', { host: '::1', port: '8000' }, infoHash)
+
+  discovery.once('peer', function (addr) {
+    t.equal(addr, '1.2.3.4:8000')
+  })
+  dhtv6.emit('peer', { host: '1.2.3.4', port: '8000' }, infoHash)
+
+  discovery.destroy(function () {
+    t.pass()
+    dhtv4.destroy()
+    dhtv6.destroy()
+  })
+})
+

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,11 +3,11 @@ var DHT = require('bittorrent-dht')
 var randombytes = require('randombytes')
 var test = require('tape')
 var common = require('./common')
-/*var log = require('why-is-node-running')
+/* var log = require('why-is-node-running')
 
 setInterval(function () {
   log() // logs out active handles that are keeping node running
-}, 5000)*/
+}, 5000) */
 
 common.wrapTest(test, 'initialize with dht', function (t, ipv6) {
   t.plan(1)
@@ -55,7 +55,7 @@ common.wrapTest(test, 'initialize without dht', function (t, ipv6) {
   })
 })
 
-test('use ipv4 and ipv6 together', function(t) {
+test('use ipv4 and ipv6 together', function (t) {
   t.plan(3)
 
   var dhtv4 = new DHT({ipv6: false})

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,12 @@
+exports.wrapTest = function (test, str, func) {
+    test('ipv4 ' + str, function (t) {
+        func(t, false)
+        if (t._plan) {
+            t.plan(t._plan + 1)
+        }
+
+        t.test('ipv6 ' + str, function (newT) {
+            func(newT, true)
+        })
+    })
+}

--- a/test/common.js
+++ b/test/common.js
@@ -1,12 +1,12 @@
 exports.wrapTest = function (test, str, func) {
-    test('ipv4 ' + str, function (t) {
-        func(t, false)
-        if (t._plan) {
-            t.plan(t._plan + 1)
-        }
+  test('ipv4 ' + str, function (t) {
+    func(t, false)
+    if (t._plan) {
+      t.plan(t._plan + 1)
+    }
 
-        t.test('ipv6 ' + str, function (newT) {
-            func(newT, true)
-        })
+    t.test('ipv6 ' + str, function (newT) {
+      func(newT, true)
     })
+  })
 }

--- a/test/reuse-dht.js
+++ b/test/reuse-dht.js
@@ -2,28 +2,30 @@ var Discovery = require('../')
 var DHT = require('bittorrent-dht')
 var randombytes = require('randombytes')
 var test = require('tape')
+var common = require('./common')
 
-test('re-use dht, verify that peers are filtered', function (t) {
+common.wrapTest(test, 're-use dht, verify that peers are filtered', function (t, ipv6) {
   t.plan(3)
   var infoHash1 = randombytes(20)
   var infoHash2 = randombytes(20)
 
-  var dht = new DHT()
+  var dht = new DHT({ipv6: ipv6})
   var discovery = new Discovery({
     infoHash: infoHash1,
     peerId: randombytes(20),
     port: 6000,
-    dht: dht
+    dht: ipv6 ? false : dht,
+    dht6: ipv6 ? dht : false
   })
 
   discovery.once('peer', function (addr) {
-    t.equal(addr, '1.2.3.4:8000')
+    t.equal(addr, ipv6 ? '[::1]:8000' : '1.2.3.4:8000')
   })
-  dht.emit('peer', { host: '1.2.3.4', port: '8000' }, infoHash1)
+  dht.emit('peer', { host: ipv6 ? '::1' : '1.2.3.4', port: '8000' }, infoHash1)
 
   // Only peers for `infoHash1` should get emitted, none from `infoHash2`
   discovery.once('peer', function (addr) {
-    t.equal(addr, '4.5.6.7:8000')
+    t.equal(addr, ipv6 ? '[::4]:8000' : '4.5.6.7:8000')
 
     discovery.destroy(function () {
       dht.destroy(function () {
@@ -31,7 +33,7 @@ test('re-use dht, verify that peers are filtered', function (t) {
       })
     })
   })
-  dht.emit('peer', { host: '2.3.4.5', port: '8000' }, infoHash2) // discovery should not emit this peer
-  dht.emit('peer', { host: '3.4.5.6', port: '8000' }, infoHash2) // discovery should not emit this peer
-  dht.emit('peer', { host: '4.5.6.7', port: '8000' }, infoHash1)
+  dht.emit('peer', { host: ipv6 ? '::2' : '2.3.4.5', port: '8000' }, infoHash2) // discovery should not emit this peer
+  dht.emit('peer', { host: ipv6 ? '::3' : '3.4.5.6', port: '8000' }, infoHash2) // discovery should not emit this peer
+  dht.emit('peer', { host: ipv6 ? '::4' : '4.5.6.7', port: '8000' }, infoHash1)
 })


### PR DESCRIPTION
[k-rpc-socket](https://github.com/mafintosh/k-rpc-socket/pull/6) | [k-rpc](https://github.com/mafintosh/k-rpc/pull/5) | [bittorrent-dht](https://github.com/feross/bittorrent-dht/pull/144) | torrent-discovery | [webtorrent](https://github.com/feross/webtorrent/pull/950)

This is one of many pull requests across the WebTorrent ecosystem to add IPv6 DHT support, as per https://github.com/feross/bittorrent-dht/issues/88

Per [the BEP 32 statement about maintaining distinct IPv4/IPv6 DHTs](http://www.bittorrent.org/beps/bep_0032.html#operation) and the discussion on https://github.com/feross/bittorrent-dht/issues/88, my implementation requires separate instances of `bittorrent-dht` and everything below it on the protocol stack (`k-rpc` and `k-rpc-socket`). `torrent-discovery` maintains up to two `DHT` instances, one for each IP version used. Fortunately, WebTorrent already supports IPv6 peers, so no changes are needed in it beyond properly using the IPv6 DHT, if enabled in the options.

The best way to run all of my changes is by using the [npm link](https://docs.npmjs.com/cli/link) command. Assuming that all of the necessary modules (`k-rpc-socket`, `k-rpc`, `bittorrent-dht`, `torrent-discovery`, `webtorrent`, and `webtorrent-cli` are sibling directories, the following commands will set things up properly (starting from the parent directory):

```
cd k-rpc-socket
npm install
npm link
cd ../k-rpc
npm install
npm link k-rpc-socket
npm link
cd ../bittorrent-dht
npm install
npm link k-rpc
npm link
cd ../torrent-discovery
npm install
npm link bittorrent-dht
npm link
cd ../webtorrent
npm install
npm link bittorrent-dht
npm link torrent-discovery
npm link
cd ../webtorrent-cli
npm install
npm link webtorrent
```

From there, you can test and run individual modules as you choose.

---

**torrent-discovery** specific notes:

This PR allows `torrent-discovery` to handle up to two `DHT` instances, one for each IP version used. To control the IPv6 instance, I've added a `dht6` parameter to the constructor, which behaves in exactly the same way as the regular `dht` parameter. As always, tests are wrapped in order to be run for either IPv4 and IPv6. I've added a separate test to exercise both simultaneously.

Notes:
- Peers are emitted the same, regardless of which `DHT` instance they come from. Since users of this library already need to be able to handle IPv4 and IPv6 peers (since `bittorrent-dht` supports IPv4 and IPV6 trackers), this should be fine.

Caveats:
- [This code](https://github.com/feross/torrent-discovery/pull/27/files#diff-168726dbe96b3ce427e7fedce31bb0bcR82) is fairly ugly, but it prevents quite a bit of copy-pasting. If it's too unreadable, I can change it to a more verbose but less complicated implementation.
