### PR TITLE
fix peer DHT event when infoHash is upper case

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Discovery (opts) {
     ? opts.peerId
     : opts.peerId.toString('hex')
   self.infoHash = typeof opts.infoHash === 'string'
-    ? opts.infoHash
+    ? opts.infoHash.toLowerCase()
     : opts.infoHash.toString('hex')
   self._port = opts.port // torrent port
   self._userAgent = opts.userAgent // User-Agent header for http requests


### PR DESCRIPTION
With an infoHash like `88594AAACBDE40EF3E2510C47374EC0AA396C08E`, the `peer` event coming from the DHT was never triggered.