### PR TITLE
Add "chromeapp" field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "browser": {
     "bittorrent-dht/client": false
   },
+  "chromeapp": {},
   "bugs": {
     "url": "https://github.com/webtorrent/torrent-discovery/issues"
   },


### PR DESCRIPTION
I'm attempting to make a defacto standard for specifying Chrome App dependency substitutions using the `"chromeapp"` field in `package.json`.

The `"chromeapp"` field is just like the [`"browser"` field in `package.json`](https://github.com/defunctzombie/package-browser-field-spec) except it's intended for Chrome Apps instead of a generic browser environment. Bundler tools like `browserify` or `webpack` can be configured to look for the `"chromeapp"` field instead of the `"browser"` field when doing a build for a Chrome App.

In this specific package, since Chrome Apps can use raw sockets we want to undo the disabling of the DHT client that occurs in the normal browser build.