### PR TITLE
fix: fully exclude bittorrent-dht in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://webtorrent.io"
   },
   "browser": {
-    "bittorrent-dht/client.js": false,
+    "bittorrent-dht": false,
     "bittorrent-lsd": false
   },
   "chromeapp": {},


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR amends the `browser` field in the `package.json` to exclude the entirety of `bittorrent-dht` in the browser, rather than only `bittorrent-dht/client.js`. This change is being made because the webtorrent `package.json`'s browser field is ignored by esbuild (used by esm.sh), leading to `bittorrent-dht` being enabled in the browser and causing `webtorrent` to crash.

I have additionally confirmed that this update does not break the webpack builds generated in webtorrent/dist, and is a quick win to get esm.sh working again.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
